### PR TITLE
Fix sorting crash when missing pages

### DIFF
--- a/golden-ticket.php
+++ b/golden-ticket.php
@@ -467,8 +467,8 @@ jQuery(document).ready(function($){
             titleMap[pair[0]] = pair[1];
         });
         ids.sort(function(a, b){
-            var ta = titleMap[a].toLowerCase();
-            var tb = titleMap[b].toLowerCase();
+            var ta = (titleMap[a] || '').toLowerCase();
+            var tb = (titleMap[b] || '').toLowerCase();
             return ta < tb ? -1 : (ta > tb ? 1 : 0);
         });
         ids.forEach(function(id){


### PR DESCRIPTION
## Summary
- prevent JavaScript error in settings preview when a whitelisted page was deleted

## Testing
- `php -l golden-ticket.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68408da72c1483209940c12b306417e6