### PR TITLE
Add PHPUnit tests for fle_sanitize_page_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,10 @@ First public release. No prior versions to upgrade from.
 
 == License ==  
 This plugin is licensed under the GNU General Public License v2.0 or later.
+
+== Development ==
+
+To run the unit tests:
+
+1. Install PHPUnit (for example with Composer).
+2. Execute `vendor/bin/phpunit` from the plugin directory.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="GoldenTicket Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/FleSanitizePageListTest.php
+++ b/tests/FleSanitizePageListTest.php
@@ -1,0 +1,38 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class FleSanitizePageListTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_POST = [];
+        $GLOBALS['options'] = [];
+    }
+
+    public function test_add_ids_merges_with_existing()
+    {
+        $GLOBALS['options']['fle_allowed_pages'] = '1,2';
+        $_POST['fle_allowed_pages_action'] = 'add';
+
+        $result = fle_sanitize_page_list(['2', 3, 4]);
+        $this->assertSame('1,2,3,4', $result);
+    }
+
+    public function test_remove_ids_subtracts_from_existing()
+    {
+        $GLOBALS['options']['fle_allowed_pages'] = '1,2,3';
+        $_POST['fle_allowed_pages_action'] = 'remove';
+
+        $result = fle_sanitize_page_list([2]);
+        $this->assertSame('1,3', $result);
+    }
+
+    public function test_invalid_values_are_sanitized()
+    {
+        $GLOBALS['options']['fle_allowed_pages'] = '5';
+        $_POST['fle_allowed_pages_action'] = 'add';
+
+        $result = fle_sanitize_page_list([-3, '5', 5, 0]);
+        $this->assertSame('5,3', $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+// Basic test bootstrap for golden-ticket plugin.
+
+// Prevent plugin from exiting if ABSPATH is not defined.
+define('ABSPATH', __DIR__);
+
+// Simple stubs for WordPress functions used during plugin loading.
+if (!function_exists('add_filter')) {
+    function add_filter(...$args) {}
+}
+if (!function_exists('add_action')) {
+    function add_action(...$args) {}
+}
+if (!function_exists('register_setting')) {
+    function register_setting(...$args) {}
+}
+if (!function_exists('add_options_page')) {
+    function add_options_page(...$args) {}
+}
+if (!function_exists('plugin_basename')) {
+    function plugin_basename($file) { return $file; }
+}
+
+// Stubs used by fle_sanitize_page_list
+if (!function_exists('get_option')) {
+    function get_option($name, $default = '') {
+        return isset($GLOBALS['options'][$name]) ? $GLOBALS['options'][$name] : $default;
+    }
+}
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str) { return $str; }
+}
+if (!function_exists('absint')) {
+    function absint($value) { return abs(intval($value)); }
+}
+
+// Include the plugin file once for all tests.
+require_once __DIR__ . '/../golden-ticket.php';


### PR DESCRIPTION
## Summary
- set up `phpunit.xml.dist`
- add unit tests for `fle_sanitize_page_list`
- include a bootstrap with WordPress stubs
- document running the tests in README

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408e9c465483209c4022d690819b39