### PR TITLE
Handle missing titles in preview sort

### DIFF
--- a/golden-ticket.php
+++ b/golden-ticket.php
@@ -467,8 +467,8 @@ jQuery(document).ready(function($){
             titleMap[pair[0]] = pair[1];
         });
         ids.sort(function(a, b){
-            var ta = titleMap[a].toLowerCase();
-            var tb = titleMap[b].toLowerCase();
+            var ta = (titleMap[a] || '').toLowerCase();
+            var tb = (titleMap[b] || '').toLowerCase();
             return ta < tb ? -1 : (ta > tb ? 1 : 0);
         });
         ids.forEach(function(id){


### PR DESCRIPTION
## Summary
- prevent `renderPreview` from crashing if a stored ID isn't in the page list

## Testing
- `node - <<'NODE'
var ids=[1,2,3];
var allPages=[[1,'Apple'],[3,'Banana']];
var titleMap={};
allPages.forEach(function(pair){titleMap[pair[0]]=pair[1];});
ids.sort(function(a,b){var ta=(titleMap[a]||'').toLowerCase(); var tb=(titleMap[b]||'').toLowerCase(); return ta<tb?-1:(ta>tb?1:0);});
console.log(ids);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68408e81aef083209365402ea4550ccb