### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ add_filter( 'the_golden_tickets_allowed_posts', function( $ids ) {
 return $ids;
 });
 
-pgsql
-Copy
-Edit
 For more advanced integration, see **Golden Ticket Pro**.
 
 = What happens when I deactivate the plugin? =  


### PR DESCRIPTION
## Summary
- remove stray `pgsql`, `Copy`, and `Edit` lines from README

## Testing
- `php -l golden-ticket.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68408e7a8a588320aaebbff00701ed06